### PR TITLE
Add plain text export feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A user-friendly guitar tablature editor and sharing platform built with Next.js.
 - 📱 Mobile-first design
 - 🔄 Real-time updates
 - 📤 Easy sharing
+- 📥 Export to plain text
 - 🎨 Clean, modern interface
 - ♿ Accessibility focused
 

--- a/components/controls/index.tsx
+++ b/components/controls/index.tsx
@@ -1,6 +1,8 @@
 import styles from './controls.module.scss';
 import Icon from '../icon';
 import { Show } from "../show";
+import type { Riff } from '../riff/types';
+import { riffToPlainText } from '../../utils/text';
 
 interface EditButtonProps {
   isEdit: boolean;
@@ -15,12 +17,14 @@ const EditButton = ({ isEdit, setIsEdit }: EditButtonProps) => {
 interface EditPaneProps extends EditButtonProps {
   pasteValue: number;
   onNoteValueChange(value: number): void;
+  riff: Riff;
 }
 export const EditPane = ({
   isEdit,
   setIsEdit,
   pasteValue,
   onNoteValueChange,
+  riff,
 }: EditPaneProps) => {
   return (
     <section className={styles.editControls}>
@@ -71,6 +75,21 @@ export const EditPane = ({
         </>
       </Show>
       <div className={styles.editGeneral}>
+        <button
+          onClick={() => {
+            const text = riffToPlainText(riff);
+            const blob = new Blob([text], { type: 'text/plain' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'tab.txt';
+            a.click();
+            URL.revokeObjectURL(url);
+          }}
+        >
+          {/* Export */}
+          <Icon id="icon--copy" />
+        </button>
         <button
           onClick={() => {
             if (!navigator.clipboard) return;

--- a/components/riff/index.tsx
+++ b/components/riff/index.tsx
@@ -148,7 +148,7 @@ const Riff = () => {
           </div>
         </div>
       </div>
-      <EditPane {...{ isEdit, setIsEdit, pasteValue, onNoteValueChange }} />
+      <EditPane {...{ isEdit, setIsEdit, pasteValue, onNoteValueChange, riff }} />
     </div>
   );
 };

--- a/utils/__tests__/text.test.ts
+++ b/utils/__tests__/text.test.ts
@@ -1,0 +1,31 @@
+import { riffToPlainText } from '../text';
+
+const riff = {
+  strungs: [
+    { notes: [{ number: 0 }, { number: 1 }, {}] },
+    { notes: [{}, { number: 2 }, {}] },
+  ],
+};
+
+describe('riffToPlainText', () => {
+  it('converts riff to ascii tab text', () => {
+    expect(riffToPlainText(riff, ['e', 'B'])).toBe('e|0-1|\nB|--2|');
+  });
+
+  it('outputs lines of equal length', () => {
+    const complex = {
+      strungs: [
+        { notes: [{ number: 0 }, {}, {}, {}, {}, { number: 0 }] },
+        { notes: [{}, {}, { number: 0 }, {}, { number: 0 }, { number: 1 }] },
+        { notes: [{}, { number: 0 }, {}, {}, {}, { number: 4 }] },
+        { notes: Array(6).fill({}) },
+        { notes: Array(6).fill({}) },
+        { notes: [{ number: 0 }, {}, {}, {}, {}, { number: 0 }] },
+      ],
+    };
+    const text = riffToPlainText(complex);
+    const lines = text.split('\n');
+    const lengths = lines.map((l) => l.length);
+    expect(new Set(lengths).size).toBe(1);
+  });
+});

--- a/utils/text/index.ts
+++ b/utils/text/index.ts
@@ -1,0 +1,38 @@
+import type { Riff } from '../../components/riff/types';
+import { truncateRiff } from '../url';
+
+const DEFAULT_STRING_NAMES = ['e', 'B', 'G', 'D', 'A', 'E'];
+
+export const riffToPlainText = (
+  riff: Riff,
+  stringNames: string[] = DEFAULT_STRING_NAMES
+) => {
+  const { strungs } = truncateRiff(riff);
+  const maxNotes = Math.max(...strungs.map((s) => s.notes.length));
+
+  const colWidths = Array.from({ length: maxNotes }, (_, noteIndex) =>
+    Math.max(
+      ...strungs.map((strung) => {
+        const fret = strung.notes[noteIndex] || {};
+        const len = fret.number !== undefined ? String(fret.number).length : 1;
+        return noteIndex === maxNotes - 1 ? len : len + 1;
+      })
+    )
+  );
+
+  return strungs
+    .map((strung, i) => {
+      const name = stringNames[i] || `s${i}`;
+      const notes = Array.from({ length: maxNotes }, (_, noteIndex) => {
+        const note = strung.notes[noteIndex] || {};
+        const width = colWidths[noteIndex];
+        if (note.number !== undefined) {
+          const value = String(note.number);
+          return value + '-'.repeat(width - value.length);
+        }
+        return '-'.repeat(width);
+      }).join('');
+      return `${name}|${notes}|`;
+    })
+    .join('\n');
+};


### PR DESCRIPTION
## Summary
- add a `riffToPlainText` util
- allow exporting the tab as text in the controls panel
- document the new feature in the README
- test text export util
- fix plain text export alignment

## Testing
- `npm run lint`
- `npm test`
